### PR TITLE
Remove slf4j-simple dependency to prevent logging conflicts

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -121,10 +121,6 @@
       <groupId>org.slf4j</groupId>
       <artifactId>slf4j-api</artifactId>
     </dependency>
-    <dependency>
-      <groupId>org.slf4j</groupId>
-      <artifactId>slf4j-simple</artifactId>
-    </dependency>
 
     <!-- Annotations -->
     <dependency>


### PR DESCRIPTION
### Problem
The SDK currently includes `slf4j-simple` as a dependency, which causes conflicts when consumers use different SLF4J implementations like Logback or Log4j2. This results in the following error:

```
LoggerFactory is not a Logback LoggerContext but Logback is on the classpath.
Either remove Logback or the competing implementation (class org.slf4j.simple.SimpleLoggerFactory)
```

SLF4J will pick one implementation non-deterministically when multiple bindings are present, leading to:
- Unexpected logging behavior
- Application startup failures (especially in Spring Boot apps)
- Inability for consumers to control their logging configuration

### Solution
This PR removes the `slf4j-simple` dependency from the project. The SDK only needs the SLF4J API (`slf4j-api`), not a concrete implementation. This follows the standard practice for library development:

- **Libraries should depend on logging APIs only** (slf4j-api)
- **Applications should choose the logging implementation** (logback, log4j2, etc.)

### Changes
- Removed `org.slf4j:slf4j-simple:2.0.17` from dependencies
- Retained `org.slf4j:slf4j-api:2.0.17` (required for the SDK to log)